### PR TITLE
Adding 4 new settings and readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $.fn.dayparts.defaults = {
         am: 'AM',
         pm: 'PM',
         presets: 'Presets',
+        presetsSubtitle: '',
         choosePreset: 'Select a Preset'
     },
     data: []

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ __Worth noting:__ all text - days of the week, preset names, and labels - is pas
 `data` is whatever selected dayparts you want to have initially selected.  It takes the form of an array of objects as follows:
 ```javascript
 [{day: 0, hour: 23}, {day: 1, hour: 0}]
-
+```
 Values for `day` are 0-6 (Sunday to Saturday) and values for `hour` are 0-23.
 
-```
 This is an example to generate a `Full Coverage` `data`:
 ```javascript
 var data = [];

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Values for `day` are 0-6 (Sunday to Saturday) and values for `hour` are 0-23.
 This is an example to generate a `Full Coverage` `data`:
 ```javascript
 var data = [];
-for (day=0;day<7;day++){
-    for (hour=0;hour<24;hour++){
+for (var day=0;day<7;day++){
+    for (var hour=0;hour<24;hour++){
         data[data.length]={day: day, hour: hour};
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All options can have their defaults overridden (overrode?) and also can be speci
 
 ```javascript
 $.fn.dayparts.defaults = {
+    disabled: false, 
     i18nfunc: function(input){ return input; },
     days: {0: 'Sunday', 1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday', 5: 'Friday', 6: 'Saturday'},
     weekStartsOn: 0,

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ __Worth noting:__ all text - days of the week, preset names, and labels - is pas
 `data` is whatever selected dayparts you want to have initially selected.  It takes the form of an array of objects as follows:
 ```javascript
 [{day: 0, hour: 23}, {day: 1, hour: 0}]
+
+Values for `day` are 0-6 (Sunday to Saturday) and values for `hour` are 0-23.
+
 ```
 This is an example to generate a `Full Coverage` `data`:
 ```javascript
@@ -62,10 +65,6 @@ for (day=0;day<7;day++){
     }
 }
 ```
-
-
-Values for `day` are 0-6 (Sunday to Saturday) and values for `hour` are 0-23.
-
 
 Most other options are self-explanitory.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $.fn.dayparts.defaults = {
     days: {0: 'Sunday', 1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday', 5: 'Friday', 6: 'Saturday'},
     weekStartsOn: 0,
     use24HFormat: true,
+    change0Hour: true,
+    show2DigitsHour: false,
     showPresets: true,
     presets: [
         {label:"Full Coverage", days:[0,1,2,3,4,5,6], hours:[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]},

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ __Worth noting:__ all text - days of the week, preset names, and labels - is pas
 ```javascript
 [{day: 0, hour: 23}, {day: 1, hour: 0}]
 ```
+This is an example to generate a `Full Coverage` `data`:
+```javascript
+var data = [];
+for (day=0;day<7;day++){
+    for (hour=0;hour<24;hour++){
+        data[data.length]={day: day, hour: hour};
+    }
+}
+```
+
 
 Values for `day` are 0-6 (Sunday to Saturday) and values for `hour` are 0-23.
 

--- a/js/jquery.dayparts.js
+++ b/js/jquery.dayparts.js
@@ -21,9 +21,11 @@
 		var $el = $(this);
 
 		var dataChange = function(pointA, pointB, dragging) {
-			toggleGrid(pointA, pointB, $table, dragging);
-			// Trigger a catchable event other stuff can listen to
-			if (!dragging) $el.trigger('daypartsUpdate');
+			if (!settings.disabled){
+                            toggleGrid(pointA, pointB, $table, dragging);
+                            // Trigger a catchable event other stuff can listen to
+                            if (!dragging) $el.trigger('daypartsUpdate');
+                        }
 		};
 
 		var settings = $.extend({}, $.fn.dayparts.defaults, options);
@@ -94,7 +96,6 @@
 						.data('preset', preset)
 						.val(index)
 				);
-
 				var data = [];
 				$.each(preset.days, function(day) {
 					var row = [];
@@ -107,6 +108,9 @@
 				};
 
 			});
+                        if (settings.disabled){
+                            $select.prop('disabled', true);
+                        }
 			$td.append($select);
 
 			var $label = $("<td />").addClass('cell-label presets-label').html(
@@ -267,14 +271,15 @@
 	};
 
 	$.fn.dayparts.defaults = {
-		i18nfunc: function(input){ return input; },
+		disabled: false,
+                i18nfunc: function(input){ return input; },
 		days: {0: 'Sunday', 1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday', 5: 'Friday', 6: 'Saturday'},
 		weekStartsOn: 0,
 		use24HFormat: true,
 		change0Hour: true,
 		show2DigitsHour: false,
 		showPresets: true,
-		presets: [
+                presets: [
 			{label:"Full Coverage", days:[0,1,2,3,4,5,6], hours:[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]},
 			{label:"Afternoons", days:[0,1,2,3,4,5,6], hours:[12,13,14,15,16,17]},
 			{label:"Evenings", days:[0,1,2,3,4,5,6], hours:[18,19,20,21,22,23]},

--- a/js/jquery.dayparts.js
+++ b/js/jquery.dayparts.js
@@ -111,13 +111,25 @@
                         if (settings.disabled){
                             $select.prop('disabled', true);
                         }
-			$td.append($select);
-
-			var $label = $("<td />").addClass('cell-label presets-label').html(
+                        
+                        var $presetsSubtitle = $("<span />").addClass('cell-label presetsSubtitle-label').html(
+                            settings.i18nfunc(settings.labels.presetsSubtitle)
+                        );
+                
+                        //Presets subtitle before select
+			$td.append($presetsSubtitle);
+                        
+                        //Select
+                        $td.append($select);
+                        
+                        var $label = $("<td />").addClass('cell-label presets-label').html(
 				settings.i18nfunc(settings.labels.presets)
 			);
 			var $tr = $("<tr />");
+			
+			//Presets title before subtitle and select
 			$tr.append($label).append($td);
+
 			$thead.append($tr);
 
 		}
@@ -292,6 +304,7 @@
 			am: 'AM',
 			pm: 'PM',
 			presets: 'Presets',
+			presetsSubtitle: '',
 			choosePreset: 'Select a Preset'
 		},
 		data: []

--- a/js/jquery.dayparts.js
+++ b/js/jquery.dayparts.js
@@ -33,17 +33,25 @@
 		var drag_current = null;
 
 		var $table = $('<table />').addClass('dayparts table');
-
+                
+                var minTwoDigits = function (n) {
+                    return (n < 10 ? '0' : '') + n;
+                };
+                
 		var hours = {};
 		for (var i=0; i<24; i++){
 			var thishour = i;
 			if (!settings.use24HFormat) {
 				if (thishour > 12) thishour -= 12;
-				if (thishour == 0) thishour = 12;
+				if (settings.change0Hour && thishour === 0) thishour = 12;
 			} else {
-				if (thishour == 0) thishour = 24;
+				if (settings.change0Hour && thishour === 0) thishour = 24;
 			}
-			hours[i] = thishour;
+                        if (settings.show2DigitsHour){
+                            hours[i] = minTwoDigits(thishour);
+                        }else{
+                            hours[i] = thishour;
+                        }
 		}
 
 		var $thead = $("<thead />");
@@ -263,6 +271,8 @@
 		days: {0: 'Sunday', 1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday', 5: 'Friday', 6: 'Saturday'},
 		weekStartsOn: 0,
 		use24HFormat: true,
+		change0Hour: true,
+		show2DigitsHour: false,
 		showPresets: true,
 		presets: [
 			{label:"Full Coverage", days:[0,1,2,3,4,5,6], hours:[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]},
@@ -339,3 +349,4 @@
 	};
 
 }));
+


### PR DESCRIPTION
- change0Hour (Default as true):
  You are able to keep the 0 hour as 0 (by default it changes to 24 or 12 based in use24HFormat).
- show2DigitsHour (Default as false):
  It shows all hours in 00 format.
- disabled (Default as false):
  Use dayparts as read only.
- presetsSubtitle (Default as ''):
  It shows some text before the presets.

Also adding an example to generate data.
